### PR TITLE
Build wheels on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.5.0
+        env:
+          CIBW_ARCHS_WINDOWS: "auto"
+          CIBW_ARCHS_LINUX: "auto"
+          CIBW_ARCHS_MACOS: "all"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,11 @@ setup(
                 "libgfxd/uc.c",
             ],
             include_dirs=["libgfxd"],
+            extra_compile_args = [
+                "-std=c11",
+                "-Wall",
+                "-g",
+            ],
         ),
     ],
     cmdclass={'build_ext': build_ext},


### PR DESCRIPTION
shamelessly stole the CI file from rabbitizer.
Don't ask me what the stuff does exactly, I just know it somehow works 