### PR TITLE
msvc c11 enable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ class CTypesExtension(Extension):
 class build_ext(build_ext_orig):
     def build_extension(self, ext):
         self._ctypes = isinstance(ext, CTypesExtension)
+        if self.compiler.compiler_type is "msvc":
+            for e in self.extensions:
+                e.extra_compile_args=["/std:c11"]
         return super().build_extension(ext)
 
     def get_export_symbols(self, ext):
@@ -47,7 +50,7 @@ setup(
                 "libgfxd/uc_f3dexb.c",
                 "libgfxd/uc.c",
             ],
-            include_dirs=["libgfxd"],
+            include_dirs=["libgfxd"]
         ),
     ],
     cmdclass={'build_ext': build_ext},


### PR DESCRIPTION
The package is failing to install on windows because libgfxd uses C11 features that are not enabled by default with msvc. This sets the std:c11 flag when the compiler is msvc so python -m pip install . works.

Solution was inspired by this [stack overflow](https://stackoverflow.com/questions/724664/python-distutils-how-to-get-a-compiler-that-is-going-to-be-used).

I'm inexperienced with python so I may have missed something.