### PR TITLE
Fix CI upload_pypi job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           pattern: artifact-*
+          merge-multiple: true
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.8.11


### PR DESCRIPTION
Per https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md
with `pattern` the artifacts are being downloaded in subfolders named after the artifacts' names
`merge-multiple: true` should mean to not use subfolders and directly write into `path: dist` instead