### PR TITLE
Update the Github Actions versions used by CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
         os: [ubuntu-22.04, macos-14, windows-2022]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v3.2.1
         env:
           CIBW_ARCHS_WINDOWS: "auto"
           CIBW_ARCHS_LINUX: "auto"
@@ -31,7 +31,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build sdist
         run: pipx run build --sdist
@@ -46,13 +46,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           pattern: artifact-*
           merge-multiple: true
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.8.11
+      - uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Compile libgfxd
         run: gcc -shared -fPIC libgfxd/gfxd.c libgfxd/uc_f3d.c libgfxd/uc_f3db.c libgfxd/uc_f3dex.c libgfxd/uc_f3dex2.c libgfxd/uc_f3dexb.c libgfxd/uc.c -o libgfxd.so

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="pygfxd",
-    version="1.0.4",
+    version="1.0.5",
     author="Tharo",
     description="Python bindings for libgfxd",
     long_description=long_description,


### PR DESCRIPTION
This should fix the error when trying to publish a new version of the library, or at least that's what I understood from reading https://github.com/pypa/gh-action-pypi-publish/issues/351